### PR TITLE
fix: make PDF preview and generate button work on mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,12 +13,12 @@ function PdfPreviewModal({
 }) {
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/60 p-0 sm:p-4"
       role="dialog"
       aria-modal="true"
       aria-labelledby="pdf-preview-title"
     >
-      <div className="flex max-h-[90vh] w-full max-w-4xl flex-col rounded-xl bg-white shadow-xl">
+      <div className="flex h-[95dvh] sm:h-auto sm:max-h-[90vh] w-full sm:max-w-4xl flex-col rounded-t-2xl sm:rounded-xl bg-white shadow-xl">
         <div className="flex shrink-0 items-center justify-between border-b border-slate-200 px-4 py-3">
           <h2 id="pdf-preview-title" className="text-lg font-semibold text-slate-800">
             Vista previa del PDF
@@ -26,17 +26,16 @@ function PdfPreviewModal({
           <button
             type="button"
             onClick={onClose}
-            className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-slate-700 hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2"
+            className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm sm:px-4 sm:text-base text-slate-700 hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 touch-manipulation"
           >
             Cerrar
           </button>
         </div>
-        <div className="min-h-0 flex-1 overflow-auto p-4">
+        <div className="min-h-0 flex-1 overflow-auto p-3 sm:p-4">
           <iframe
             src={pdfUrl}
             title="Vista previa del PDF"
-            className="w-full rounded border border-slate-200 bg-white"
-            style={{ height: '600px' }}
+            className="w-full h-[calc(95dvh_-_5rem)] min-h-[50vh] sm:h-[600px] rounded border border-slate-200 bg-white"
           />
         </div>
       </div>
@@ -76,22 +75,35 @@ function AppContent() {
         <p className="text-slate-600 mt-2">Elige el modo, sube las imágenes y genera tu baraja imprimible.</p>
       </header>
 
-      <main className="max-w-4xl mx-auto space-y-8">
+      <main className={`max-w-4xl mx-auto space-y-8 ${hasImages && hasLayout ? 'pb-24 sm:pb-0' : ''}`}>
         <GameModeSelector />
         <UploadZone />
 
         {hasImages && hasLayout && (
-          <section className="flex justify-center">
-            <button
-              type="button"
-              onClick={handleGeneratePdf}
-              disabled={isGeneratingPdf}
-              className="px-6 py-3 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 disabled:opacity-60 disabled:cursor-not-allowed font-medium"
-              aria-label="Generar PDF de la baraja"
-            >
-              {isGeneratingPdf ? 'Generando…' : 'Generar PDF'}
-            </button>
-          </section>
+          <>
+            <section className="hidden sm:flex justify-center">
+              <button
+                type="button"
+                onClick={handleGeneratePdf}
+                disabled={isGeneratingPdf}
+                className="px-6 py-3 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 disabled:opacity-60 disabled:cursor-not-allowed font-medium"
+                aria-label="Generar PDF de la baraja"
+              >
+                {isGeneratingPdf ? 'Generando…' : 'Generar PDF'}
+              </button>
+            </section>
+            <div className="fixed bottom-0 left-0 right-0 z-40 flex justify-center bg-white/95 backdrop-blur-sm border-t border-slate-200 p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] sm:hidden">
+              <button
+                type="button"
+                onClick={handleGeneratePdf}
+                disabled={isGeneratingPdf}
+                className="w-full max-w-md px-6 py-3.5 bg-emerald-600 text-white rounded-xl hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 disabled:opacity-60 disabled:cursor-not-allowed font-medium touch-manipulation shadow-lg"
+                aria-label="Generar PDF de la baraja"
+              >
+                {isGeneratingPdf ? 'Generando…' : 'Generar PDF'}
+              </button>
+            </div>
+          </>
         )}
 
         {pdfPreviewUrl && (


### PR DESCRIPTION
## Summary
Improves PDF experience on mobile: the preview modal is now responsive and the "Generar PDF" action is always visible via a sticky bar on small screens.

## Changes
- **PDF preview modal (mobile):** Full-height modal from bottom, responsive iframe height (`calc(95dvh - 5rem)` / 600px on desktop), compact close button, touch-friendly.
- **PDF tool visibility (mobile):** Sticky bottom bar with "Generar PDF" so the button is always visible without scrolling; desktop keeps the in-flow button. Main content gets bottom padding when the bar is shown to avoid overlap. Safe area inset supported for notched devices.